### PR TITLE
use set to allow passing empty string vars (fixes --save)

### DIFF
--- a/keydb/templates/secret-utils.yaml
+++ b/keydb/templates/secret-utils.yaml
@@ -20,7 +20,8 @@ stringData:
       fi
       node=$(( node + 1 ))
     done
-    cmd=$(echo keydb-server /etc/keydb/redis.conf \
+
+    set -- keydb-server /etc/keydb/redis.conf \
         --active-replica {{ .Values.activeReplicas | quote }} \
         --multi-master {{ .Values.multiMaster | quote }} \
         --appendonly {{ .Values.appendonly | quote }} \
@@ -46,11 +47,13 @@ stringData:
         {{- end }}
         {{- end }}
         {{- end }}
-        $(echo "${replicas}" | xargs))
+        $(echo "${replicas}" | xargs)
+
     if [ -z "${REDIS_PASSWORD+x}" ]; then
-      echo ${cmd}
+      echo "$@"
     else
       ESCAPED_PASSWORD=$(printf '%s\n' "$REDIS_PASSWORD" | sed -e 's/[]\/$*.^[]/\\&/g');
-      echo ${cmd} | sed "s/${ESCAPED_PASSWORD}/\*\*\*/g"
+      echo "$@" | sed "s/${ESCAPED_PASSWORD}/\*\*\*/g"
     fi
-    exec ${cmd}
+
+    exec "$@"

--- a/keydb/templates/secret-utils.yaml
+++ b/keydb/templates/secret-utils.yaml
@@ -20,8 +20,7 @@ stringData:
       fi
       node=$(( node + 1 ))
     done
-
-    set -- keydb-server /etc/keydb/redis.conf \
+    exec keydb-server /etc/keydb/redis.conf \
         --active-replica {{ .Values.activeReplicas | quote }} \
         --multi-master {{ .Values.multiMaster | quote }} \
         --appendonly {{ .Values.appendonly | quote }} \
@@ -48,12 +47,3 @@ stringData:
         {{- end }}
         {{- end }}
         $(echo "${replicas}" | xargs)
-
-    if [ -z "${REDIS_PASSWORD+x}" ]; then
-      echo "$@"
-    else
-      ESCAPED_PASSWORD=$(printf '%s\n' "$REDIS_PASSWORD" | sed -e 's/[]\/$*.^[]/\\&/g');
-      echo "$@" | sed "s/${ESCAPED_PASSWORD}/\*\*\*/g"
-    fi
-
-    exec "$@"


### PR DESCRIPTION
Use `set --` and `$@` to expand all positional parameters as is to `exec`. Previously due to echoing, an empty string param was missing when passing `--save` flag with an empty string to disable saving on disk.